### PR TITLE
Migliorato il driver per chiavetta USB rtl-sdr

### DIFF
--- a/rtl_433/src/devices/fineoffset_wh1080.c
+++ b/rtl_433/src/devices/fineoffset_wh1080.c
@@ -218,9 +218,9 @@ static int fineoffset_wh1080_callback(bitbuffer_t *bitbuffer) {
         return 0;
     }
 	
-	if (br[0] == 0xff && br[1] == 0xa0) {
+	if (br[0] == 0xff && (br[1] >> 4) == 0x0a) {
 	msg_type = 0;
-	} else if (br[0] == 0xff && br[1] == 0xb0) {
+	} else if (br[0] == 0xff && (br[1] >> 4) == 0x0b) {
 	msg_type = 1;
 	}
 	


### PR DESCRIPTION
Grazie a Roberto Vaccaro per il betatesting, risolta anomalia nella discriminazione dei dati meteo/data-ora.