### PR TITLE
Fixed incorrect behaviour in the rtl-sdr driver (rtlsdr_timesync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ sudo apt-get -y install gphoto2  python-piggyphoto dcraw libgphoto2-port10
 
 sudo apt-get -y install python-requests python-spidev python-pygame python-setuptools libusb-1.0-0-dev cmake 
 
-
+ 
+  
 
 USB library:
 - hidapi

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sudo apt-get -y install python-requests python-spidev python-pygame python-setup
 - cython
 
 
-**RTL-SDR libraries (included):**
+**RTL-SDR libraries** (included)**:**
 - cd rtl-sdr
 - mkdir build
 - cd build
@@ -55,7 +55,7 @@ sudo apt-get -y install python-requests python-spidev python-pygame python-setup
 - sudo make install 
  
 
-**RTL_433 (included, just a little modified (see /rtl_433/README-SWPI.md)):**
+**RTL_433** (included - just a little modified, see /rtl_433/README-SWPI.md)**:**
 - cd rtl_433
 - mkdir build
 - cd build
@@ -64,6 +64,6 @@ sudo apt-get -y install python-requests python-spidev python-pygame python-setup
 - sudo make install
 
 
-Main program start : sudo python swpi.py
+**Main program start:** sudo python swpi.py
 
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ sudo apt-get -y install python-requests python-spidev python-pygame python-setup
  
   
 
-USB library:
+**USB library:**
 - hidapi
 - cython-hidapi
 - cython
 
 
-RTL-SDR libraries (included):
+**RTL-SDR libraries (included):**
 - cd rtl-sdr
 - mkdir build
 - cd build
@@ -55,7 +55,7 @@ RTL-SDR libraries (included):
 - sudo make install 
  
 
-RTL_433 (included, just a little modified (see /rtl_433/README-SWPI.md)):
+**RTL_433 (included, just a little modified (see /rtl_433/README-SWPI.md)):**
 - cd rtl_433
 - mkdir build
 - cd build

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 
 A Sint Wind is a wind condition ( and other meteo data ) telephone answering machine. 
-This implementation uses a Raspberry PI with an Huawei 3G dongle. The Sint Wind is compatible with different kind of Meteo Sensors ( WH1080,Davis,TX32,BMP085 .. ).
+This implementation uses a Raspberry PI with an Huawei 3G dongle. The Sint Wind is compatible with different kind of Meteo Sensors (WH1080, Davis, TX32, BMP085...).
 
 Complete documentation on www.vololiberomontecucco.it
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ RTL-SDR libraries (included):
 - sudo make install 
  
 
-RTL_433 (included):
+RTL_433 (included, just a little modified (see /rtl_433/README-SWPI.md)):
 - cd rtl_433
 - mkdir build
 - cd build

--- a/rtl_433/README-SWPI.md
+++ b/rtl_433/README-SWPI.md
@@ -1,0 +1,5 @@
+
+Sources of this copy of rtl_433 (WH1080 decoder only) have been slightly modified 
+to (re)write received data in a txt file in /dev/shm, 
+in order to mantain compatibility with swpi's working model.
+

--- a/sensor_wh1080rtlsdr.py
+++ b/sensor_wh1080rtlsdr.py
@@ -151,7 +151,7 @@ class Sensor_WH1080RTLSDR(sensor.Sensor):
 				elif str(line['msg_type']) == '1':
 					if str(self.cfg.rtlsdr_timesync) == 'True':						
 						print "\n"
-						log("*** WH1080_RTL-SDR: Datetime data received ***")
+						log("Setting system time...")
 						try:
 							t_year = str(line['year'])
 							
@@ -180,7 +180,10 @@ class Sensor_WH1080RTLSDR(sensor.Sensor):
 							log("System time adjusted from WH1080_RTL-SDR.")
 							return "Time",0,0,0,0,"",0,0
 						except:
-							log("Error adjusting system time from WH1080_RTL-SDR")	
+							log("Error adjusting system time from WH1080_RTL-SDR")
+					else:
+						log("WH1080_RTL-SDR: rtlsdr_timesync is disabled.")
+						return "Time",0,0,0,0,"",0,0
 			except:
 					log("Received data are not in json format. Dropped...")
 					return "None",0,0,0,0,"",0,0
@@ -235,14 +238,16 @@ class Sensor_WH1080RTLSDR(sensor.Sensor):
 				time.sleep(10)
 				new_last_data_time = modification_date('/dev/shm/wh1080-rtl_433.txt')
 				
-				
-			log("New data received from WH1080_RTL-SDR station %s. Processing..." % station_id)
+			if station_id != "Time":
+				log("New data received from WH1080_RTL-SDR station %s. Processing..." % station_id)
+			else:
+				log("Datetime signal received from WH1080_RTL-SDR station. Processing...")
 			last_data_time = new_last_data_time
 						
 			station_id,temp,hum,Wind_speed,Gust_Speed,dir_code,dire,rain =  self.ReadData()
 			
 			if ( station_id == "Time"):
-				log("Datetime data received from WH1080_RTL-SDR. Sleeping while waiting for weather data...")
+				log("Sleeping while waiting for weather data...")
 				tosleep = 50-(datetime.datetime.now()-last_data_time).seconds
 				if DEBUG: print "Sleeping  ", tosleep
 				if (tosleep > 0 and tosleep < 50 ):	
@@ -267,3 +272,4 @@ if __name__ == '__main__':
 	
 	while 1:
 		ss.GetData()
+	


### PR DESCRIPTION
- Fixato un problema che faceva intervenire il watchdog usando il driver rtl-sdr se rtlsdr_timesync era disabilitato;
- Aggiunta notizia in README.md relativa alla piccola modifica operata sui sorgenti di rtl_433;
- Leggero ulteriore ritocco cosmetico di README.md .