### PR TITLE
Eliminate a warning on "Raspbian GNU/Linux 10 (buster)" and others.

### DIFF
--- a/TX23/readTX23.c
+++ b/TX23/readTX23.c
@@ -19,7 +19,7 @@ TX23 Wires:
 #include <stdio.h>
 #include <time.h>
 #include "RPi_TX23.h"
-
+#include <string.h>
 
 
 


### PR DESCRIPTION
readTX23.c:62:8: warning: implicit declaration of function ‘strcmp’ [-Wimplicit-function-declaration]
   if ((strcmp(argv[i],"--debug") == 0) || (strcmp(argv[i],"-d") == 0))
        ^~~~~~

Signed-off-by: Caz Yokoyama <caz@caztech.com>