### PR TITLE
fix negative bitLength.

### DIFF
--- a/TX23/RPi_TX23.c
+++ b/TX23/RPi_TX23.c
@@ -75,7 +75,7 @@ unsigned char RPi_TX23_GetReading(int *iDir, int *iSpeed )
 	
 	unsigned int timeout;			// Timeout for reading the port
 	struct timeval start, stop;		// Used to calculate the baud rate
-	unsigned int bitLength;	// The length of each bit in uSec
+	int bitLength;	// The length of each bit in uSec
 
 	// Local Variables
 	int startframe = 6;	//Start with binary 110
@@ -164,7 +164,10 @@ unsigned char RPi_TX23_GetReading(int *iDir, int *iSpeed )
 	gettimeofday(&delayStart,NULL);
 	delayTargetuSec = 0;
 
-	bitLength = (int)((stop.tv_usec-start.tv_usec)/3);
+	bitLength = stop.tv_usec - start.tv_usec;
+	if (bitLength < 0) /* wrap around */
+	  bitLength += 1000000;
+	bitLength /= 3;
 	bitLength += 5;
 	// Wait for a little bit to make sure we're getting the stable values
 	delayTargetuSec += (bitLength/2);TX23_DoDelay;


### PR DESCRIPTION
tv_usec in struct timeval is in micro sec. It counts from 0 to 999,999. There is an occasion that start.tv_usec is bigger than  stop.tv_usec. In that case,  bitLength is a negative value, but because it is defined as unsigned, TX23_DoDelay waits  for a long time, almost freeze.